### PR TITLE
Induction Document Fix

### DIFF
--- a/internmatch/document_templates/Induction.html
+++ b/internmatch/document_templates/Induction.html
@@ -2,7 +2,6 @@
    <head><title>Induction Documents</title>
    <style>
     .body{
-       position: absolute;
        display:block;
        margin:3em;  
        width: 618px;      


### PR DESCRIPTION
# Issue

# Description:
Fixed styling for induction documents.

# How To Test
1) Go to Internmatch.
2) View an Induction document.
3) Document should be centered in the page.